### PR TITLE
Revert to close session in `finalize_executions`

### DIFF
--- a/_common/qiskit/execute.py
+++ b/_common/qiskit/execute.py
@@ -1397,14 +1397,12 @@ def finalize_execution(completion_handler=metrics.finalize_group, report_end=Tru
     if report_end:
         metrics.end_metrics()
 
-
-def close_session():
-    # close any active session at end of the app
+    # also, close any active session at end of the app
     global session
-    if session is not None:
+    if report_end and session is not None:
         if verbose:
             print(f"... closing active session: {session_count}\n")
-        
+
         session.close()
         session = None
 


### PR DESCRIPTION
Revert the closing session part of #6 because the closing session cell was removed https://github.com/haimeng-zhang/QC-App-Oriented-Benchmarks/commit/0a53bf71e87936f2d07b78c7d9e873c3746f3865
